### PR TITLE
Add command that can be used instead of ribbon

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -40,6 +40,16 @@ export default class ImportFoundry extends Plugin {
 		});
 		// Perform additional things with the ribbon
 		ribbonIconEl.addClass('import-foundry-ribbon-class');
+		this.addCommand({
+			id: 'import-foundry',
+			name: 'Import Foundry journal.db',
+			callback: () => {
+				// Called when the user clicks the icon.
+				const modal = new FileSelectorModal(this.app);
+				modal.setHandler(this, this.readJournalEntries, this.settings[GS_OBSIDIAN_FOLDER], this.settings[GS_FOLDER_NOTES]);
+				modal.open();
+			}
+		});
 	}
 
 	onunload() {


### PR DESCRIPTION
The ribbon bar can get a bit crowded if the user has a lot of plugins, so this PR adds a command (ctrl+p import foundry) to access the same functionality, as well as making the ribbon optional via setting.